### PR TITLE
Add support for lazy requests

### DIFF
--- a/Source/FetchImage.swift
+++ b/Source/FetchImage.swift
@@ -5,6 +5,7 @@
 import SwiftUI
 import Nuke
 
+/// - WARNING: This is an API preview. It is not battle-tested yet and might signficantly change in the future.
 public final class FetchImage: ObservableObject, Identifiable {
     /// Returns the fetched image.
     ///
@@ -39,7 +40,7 @@ public final class FetchImage: ObservableObject, Identifiable {
 
     private let pipeline: ImagePipeline
     private var task: ImageTask?
-    private var loadedImageQuality: ImageQuality? = nil
+    private var loadedImageQuality: ImageQuality?
     
     private enum ImageQuality {
         case regular, low


### PR DESCRIPTION
This PR addresses issues raised in https://github.com/kean/FetchImage/issues/7 around support for `StateObject` and lazy request making, by adjusting the API of `FetchImage` to more closely mirror the suggested approach by Apple in their [Data Essentials](https://developer.apple.com/videos/play/wwdc2020/10040/) WWDC video. Example usage of this new API can be found [here](https://gist.github.com/StarLard/fb1e02f4dc616aee02970453847c1c2e).